### PR TITLE
Add an `override_location` setting.

### DIFF
--- a/core.gs
+++ b/core.gs
@@ -201,6 +201,12 @@ function createEvent(calendar, event) {
     desc += "\n\nUpdated at :\n" + new Date();
   }
 
+  if(args.override_location)
+  {
+    title = loc + ' - ' + title;
+    loc = args.override_location;
+  }
+
   var event = calendar.createEvent(title, start, end, {
     description : desc,
     location : loc

--- a/main.gs
+++ b/main.gs
@@ -17,6 +17,7 @@ var args = {
   username : "",
   password : "",
   calendar : "",
+  override_location : "", // Replace the location field of each entry
   anonymous_stats : true,  // please help us improving our service by collecting anonymous error reports
   alert_update : true, // inform you by e-mail about new updates
 };


### PR DESCRIPTION
When set, calendar entries will use that location instead of the room
number. The room number is shifted to the title field instead. This is
useful if you wish personal assistant software(e.g. Google Now) to
process that location.
